### PR TITLE
Changed 'Start Learning' buttons and added slider effect on navbar

### DIFF
--- a/script/main.js
+++ b/script/main.js
@@ -27,12 +27,19 @@ function setScrollEffectHeader() {
         $navContainer = $('header .nav-container'),
         navContainerHeight = $navContainer.height(),
         osxWindow = $(".osx-window"),
-        limitOpacity = osxWindow.position().top - navContainerHeight - 40;
+        limitOpacity = osxWindow.position().top - navContainerHeight - 40,
+        devProfileTopPos = $(".developer-profile").position().top;
 
     if (scrollFromTop > limitOpacity) {
         $navContainer.addClass('transparent');
     } else {
         $navContainer.removeClass('transparent');
+    }
+
+    if (scrollFromTop > devProfileTopPos) {
+        $navContainer.slideUp(250);
+    } else {
+        $navContainer.slideDown(100);
     }
 }
 

--- a/style/main.css
+++ b/style/main.css
@@ -291,7 +291,7 @@ main {
 
 .profile-wrapper > li footer .button.learn {
     background: none;
-    color: #CCCCCC;
+    color:  black;
     border: 2px solid #CCCCCC;
 }
 


### PR DESCRIPTION
The buttons 'Start Learning' on the developer profiles section was too hidden. Now it has more contrast. 

Added a slideUp and down animation on the navbar header once the scrolls all the way down to developer profiles section. The way it was, the navbar was overlapping too much the section and it was hiding some visual elements. Shrinking would be a nice idea too.
